### PR TITLE
Preserve dtype of input array to step function

### DIFF
--- a/jax_cfd/base/finite_differences.py
+++ b/jax_cfd/base/finite_differences.py
@@ -108,7 +108,7 @@ def forward_difference(u, axis=None):
 
 def laplacian(u: GridArray) -> GridArray:
   """Approximates the Laplacian of `u`."""
-  scales = np.square(1 / np.array(u.grid.step))
+  scales = np.square(1 / np.array(u.grid.step, dtype=u.dtype))
   result = -2 * u * np.sum(scales)
   for axis in range(u.grid.ndim):
     result += stencil_sum(u.shift(-1, axis), u.shift(+1, axis)) * scales[axis]


### PR DESCRIPTION
Hi, thanks for the fantastic library! I'm working on a project which involves running simulations using different floating point precisions. I discovered an issue when running the code in the [demo](https://github.com/google/jax-cfd/blob/main/notebooks/demo.ipynb) notebook. 

When the input array to the step function is of dtype `float32`, I expect the output to be of dtype `float32` as well. However, there is a type cast to `float64` happening somewhere, which leads to an error.

### Minimal example to reproduce
(adapted from demo code)

```
import jax
import jax.numpy as jnp
import jax_cfd.base as cfd

from jax.config import config
config.update("jax_enable_x64", True)


size = 256
density = 1.
viscosity = 1e-3
seed = 0
inner_steps = 25
outer_steps = 200
max_velocity = 2.0
cfl_safety_factor = 0.5

grid = cfd.grids.Grid((size, size), domain=((0, 2 * jnp.pi), (0, 2 * jnp.pi)))

v0 = cfd.initial_conditions.filtered_velocity_field(
    jax.random.PRNGKey(seed), grid, max_velocity)

dt = cfd.equations.stable_time_step(
    max_velocity, cfl_safety_factor, viscosity, grid)

step_fn = cfd.funcutils.repeated(
    cfd.equations.semi_implicit_navier_stokes(
        density=density, viscosity=viscosity, dt=dt, grid=grid),
    steps=inner_steps)


# Cast input into float32
for i in range(len(v0)):
    v0[i].data = v0[i].data.astype('float32')

output = step_fn(v0)
```

Because the `semi_implicit_navier_stokes` step function returns a `float64` array, the `scan` throws the error: 

> TypeError: scan carry output and input must have identical types, got
(GridArray(data=ShapedArray(float64[256,256]), offset=(1.0, 0.5), grid=Grid(shape=(256, 256), step=(0.02454369260617026, 0.02454369260617026), domain=((0.0, 6.283185307179586), (0.0, 6.283185307179586)), boundaries=('periodic', 'periodic'))), GridArray(data=ShapedArray(float64[256,256]), offset=(0.5, 1.0), grid=Grid(shape=(256, 256), step=(0.02454369260617026, 0.02454369260617026), domain=((0.0, 6.283185307179586), (0.0, 6.283185307179586)), boundaries=('periodic', 'periodic'))))
and
(GridArray(data=ShapedArray(float32[256,256]), offset=(1.0, 0.5), grid=Grid(shape=(256, 256), step=(0.02454369260617026, 0.02454369260617026), domain=((0.0, 6.283185307179586), (0.0, 6.283185307179586)), boundaries=('periodic', 'periodic'))), GridArray(data=ShapedArray(float32[256,256]), offset=(0.5, 1.0), grid=Grid(shape=(256, 256), step=(0.02454369260617026, 0.02454369260617026), domain=((0.0, 6.283185307179586), (0.0, 6.283185307179586)), boundaries=('periodic', 'periodic')))).

### Expected behaviour
The step function should return an array of the same dtype as the input array, after performing computation using the input dtype.

### Possible solution

I traced the issue to the following line in `finite_differences.py`:
`scales = np.square(1 / np.array(u.grid.step))`

The vanilla numpy array is created by default in `float64`, and so the remaining computation gets cast up to `float64`. Specifying the dtype of the numpy array to be the same as the input `GridArray` fixes the error and lets the simulation run in `float32`.