### PR TITLE
Allowing for 2/3 rule smoothing for non square grids

### DIFF
--- a/jax_cfd/spectral/utils.py
+++ b/jax_cfd/spectral/utils.py
@@ -127,10 +127,10 @@ def circular_filter_2d(grid: grids.Grid) -> spectral_types.Array:
 
 def brick_wall_filter_2d(grid: grids.Grid):
   """Implements the 2/3 rule."""
-  n, _ = grid.shape
-  filter_ = jnp.zeros((n, n // 2 + 1))
-  filter_ = filter_.at[:int(2 / 3 * n) // 2, :int(2 / 3 * (n // 2 + 1))].set(1)
-  filter_ = filter_.at[-int(2 / 3 * n) // 2:, :int(2 / 3 * (n // 2 + 1))].set(1)
+  n, m = grid.shape
+  filter_ = jnp.zeros((n, m // 2 + 1))
+  filter_ = filter_.at[:int(2 / 3 * n) // 2, :int(2 / 3 * (m // 2 + 1))].set(1)
+  filter_ = filter_.at[-int(2 / 3 * n) // 2:, :int(2 / 3 * (m // 2 + 1))].set(1)
   return filter_
 
 


### PR DESCRIPTION
Hi there,
I noticed that the function which smooths the advection term in the spectral NavierStokes2D (brick_wall_filter_2d) assumes a square grid. In this PR, I have removed this assumption, which results in a very small change to the code. 
Cheers!